### PR TITLE
Normalize .WPJ/.SRV files to ASCII (remove Polish & Slovak diacritics)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,9 @@ FROM	TO	DISTANCE	AZIMUTH	INCLINATION
 - **Cave IDs** follow the pattern `T.{region}-{number}.{sub}` (e.g., `T.C-16.01` for Jaskinia Kalacka, `T.B-14.01` for Dziura)
 - **Station naming**: `{cave_id}_{survey_id}` prefix (e.g., `tb1401_A1` for Dziura survey A1)
 - **Directory hierarchy**: Valley → Mountain/Region → Cave → Survey files
-- Polish diacritical marks are **removed** from file/directory names but may appear in metadata
+- Polish and Slovak diacritical marks are **not allowed** in `.wpj` paths, `.SRV` filenames, or survey text content used by Walls
+- Use ASCII equivalents instead (e.g., `ą->a`, `ć->c`, `ł->l`, `ó->o`, `ś->s`, `ż->z`, `č->c`, `š->s`, `ť->t`, `ž->z`)
+- Keep `_RAW/` files untouched as archival originals, even if they contain non-ASCII text
 - Files use **no BOM** encoding; some legacy files have encoding artifacts in Polish characters
 
 ### Raw Source Files (`_RAW/`)

--- a/Jaskinie-poligony/Dolina Goryczkowa/Jaskinia Zwolinskiego/JZWOLIN.SRV
+++ b/Jaskinie-poligony/Dolina Goryczkowa/Jaskinia Zwolinskiego/JZWOLIN.SRV
@@ -26,7 +26,7 @@
 12	13	3.45	320	9
 13	13.1	4.15	40	23
 13.1	13.2	2.55	136	-6
-;13.2	11	1.97	205	-48 ; pomiar powtórzony w JZWOLIN.SRV:67, odwrócony
+;13.2	11	1.97	205	-48 ; pomiar powtorzony w JZWOLIN.SRV:67, odwrocony
 13	14	3.07	278	43
 14	14.1	5	156	0
 14	15	2.65	45	28
@@ -64,7 +64,7 @@
 11.10	11.11	5.06	142	21
 11.11	11.12	2.6	55	15
 11.7	11.13	5	330	0
-11	13.2	1.97	24	48 ; pomiar powtórzony w JZWOLIN.SRV:29, odwrócony
+11	13.2	1.97	24	48 ; pomiar powtorzony w JZWOLIN.SRV:29, odwrocony
 13.2	13.3	7.98	152	22
 13.3	13.4	5.06	117	3
 13.4	13.5	5.65	175	6

--- a/Jaskinie-poligony/Dolina Koscieliska/Kominiarski Wierch/Raptawicka Turnia/System Jaskin Pawlikowskiego/Oblazkowa/OBLAZK_S.SRV
+++ b/Jaskinie-poligony/Dolina Koscieliska/Kominiarski Wierch/Raptawicka Turnia/System Jaskin Pawlikowskiego/Oblazkowa/OBLAZK_S.SRV
@@ -10,7 +10,7 @@ COORDINATOR_EMAIL	"darek.lubomski@gmail.com"
 DATA_SOURCE		"F. Filar"
 LICENSE			"http://creativecommons.org/licenses/by-sa/2.0/"
 
-TEAM "F. Filar, M. Parczewski, B. Chlipała"
+TEAM "F. Filar, M. Parczewski, B. Chlipala"
 INSTRUMENT "DistoX2"
 #]
 

--- a/Jaskinie-poligony/Dolina Koscieliska/Wysoki Grzbiet/Wysoka-7 Progow/PIONY.SRV
+++ b/Jaskinie-poligony/Dolina Koscieliska/Wysoki Grzbiet/Wysoka-7 Progow/PIONY.SRV
@@ -507,6 +507,6 @@ W7-514	W7-515	4.2	45	30
 W7-515	W7-516	6.6	73	-31
 W7-516	W7-505	7	122	-44
 
-W7-500	W7-501	7.2	72	-13	; środkowy otwór, pomiar powtórzony w III.SRV:19 ale z innymi danymi
+W7-500	W7-501	7.2	72	-13	; srodkowy otwor, pomiar powtorzony w III.SRV:19 ale z innymi danymi
 
-;W7-4	W7-5	2.8	0	90 ;pomiar powtórzony w IV.SRV:78
+;W7-4	W7-5	2.8	0	90 ;pomiar powtorzony w IV.SRV:78

--- a/Jaskinie-poligony/Dolina Malej Laki/Przechod-Kotliny/Przy Przechodzie/PRZYPRZE.SRV
+++ b/Jaskinie-poligony/Dolina Malej Laki/Przechod-Kotliny/Przy Przechodzie/PRZYPRZE.SRV
@@ -7,12 +7,12 @@ jp2	jp3	7.20	232.63	16.12
 jp3	jp200	5.22	185.60	11.04
 jp200	jp201	9.50	0.00	90.00
 jp3	jp4	3.57	261.12	24.85
-jp4	jp5	7.50	0.00	90.00 ; pomiar powtórzony w PRZYPRZE.SRV:12
-;jp5	jp6	5.74	74.57	31.63 ; pomiar powtórzony w PRZYPRZE.SRV:15
-;jp4	jp5	7.50	0.00	90.00 ; pomiar powtórzony w PRZYPRZE.SRV:10
+jp4	jp5	7.50	0.00	90.00 ; pomiar powtorzony w PRZYPRZE.SRV:12
+;jp5	jp6	5.74	74.57	31.63 ; pomiar powtorzony w PRZYPRZE.SRV:15
+;jp4	jp5	7.50	0.00	90.00 ; pomiar powtorzony w PRZYPRZE.SRV:10
 jp5	jp300	2.69	90.00	68.20
 jp5	jp400	3.64	90.00	74.05
-jp5	jp6	5.74	74.57	31.63 ; pomiar powtórzony w PRZYPRZE.SRV:11
+jp5	jp6	5.74	74.57	31.63 ; pomiar powtorzony w PRZYPRZE.SRV:11
 jp6	jp30	6.68	7.02	36.04
 jp6	jp40	6.69	52.22	75.88
 jp6	jp50	5.85	311.99	62.60

--- a/Jaskinie-poligony/Dolina Malej Laki/Przechod-Kotliny/System Wielkiej Snieznej/sniezna/WROCL.SRV
+++ b/Jaskinie-poligony/Dolina Malej Laki/Przechod-Kotliny/System Wielkiej Snieznej/sniezna/WROCL.SRV
@@ -133,11 +133,11 @@ z462	z463	177	32	4.40
 z463	z465	267	0	2.70
 z465	z69	202	-55	4.90
 z71	wr83	0	90	20.00
-;wr83	wr84	0	90	21.00 ; pomiar powtórzony w WROCL.SRV:140
+;wr83	wr84	0	90	21.00 ; pomiar powtorzony w WROCL.SRV:140
 wr83	wr85	320	19.5	19.50
 wr81	wr82	200	0	5.00
 wr82	wr83	270	0	4.50
-wr83	wr84	0	90	21.00 ; pomiar powtórzony w WROCL.SRV:136
+wr83	wr84	0	90	21.00 ; pomiar powtorzony w WROCL.SRV:136
 wr84	wr85	50	0	10.00
 wr84	wr86	0	90	7.00
 wr86	wr87	230	0	5.30

--- a/Jaskinie-poligony/Dolina Malej Laki/Wyznia Swistowka/Zaspalkowa Szczelina/ZASSZC.SRV
+++ b/Jaskinie-poligony/Dolina Malej Laki/Wyznia Swistowka/Zaspalkowa Szczelina/ZASSZC.SRV
@@ -3,8 +3,8 @@
 #note	zss0	/Zaspalkowa
 #flag	zss0	/Zaspalkowa
 #fix 	zss0 	421953.27 	5454527.64 	1743.30
-zss0 	zss1 	4.42 	215.82 	-26.87 ; pomiar powtórzony w ZASSZC.SRV:8
+zss0 	zss1 	4.42 	215.82 	-26.87 ; pomiar powtorzony w ZASSZC.SRV:8
 zss1 	zss2 	4.71 	184.48	-38.00
-;zss0 	zss1 	4.42 	215.82 	-26.87 ; pomiar powtórzony w ZASSZC.SRV:6
+;zss0 	zss1 	4.42 	215.82 	-26.87 ; pomiar powtorzony w ZASSZC.SRV:6
 zss1 	zss3 	3.60 	248.48 	33.57
 zss3 	zss4 	2.50 	0.00 	90.00


### PR DESCRIPTION
### Motivation
- Walls and cross-platform exchange of survey files are fragile when non-ASCII diacritics appear in project paths, filenames or survey text, so repository files used by Walls must use ASCII equivalents. 
- `_RAW/` directories must remain unchanged as archival originals, so only files outside `_RAW/` should be normalized.

### Description
- Added an explicit rule to `CLAUDE.md` that `.wpj` paths, `.SRV` filenames and survey text used by Walls must not contain Polish or Slovak diacritics and gave ASCII mapping examples.  
- Replaced non-ASCII letters in comments/metadata/`TEAM` fields (no numeric measurements were altered) in the following files: `Jaskinie-poligony/Dolina Goryczkowa/Jaskinia Zwolinskiego/JZWOLIN.SRV`, `Jaskinie-poligony/Dolina Koscieliska/.../OBLAZK_S.SRV`, `Jaskinie-poligony/Dolina Koscieliska/.../PIONY.SRV`, `Jaskinie-poligony/Dolina Malej Laki/.../PRZYPRZE.SRV`, `Jaskinie-poligony/Dolina Malej Laki/.../sniezna/WROCL.SRV`, and `Jaskinie-poligony/Dolina Malej Laki/.../ZASSZC.SRV`.  
- Changes were applied only to files outside `_RAW/` using a small Python translation script and saved with UTF-8 (no BOM).  
- Work was done on a separate branch `fix/ascii-diacritics-wpj-srv` and committed (`92ccec8`).

### Testing
- Ran `rg -n --pcre2 "[^\x00-\x7F]" --glob '*.SRV' --glob '*.wpj' --glob '!**/_RAW/**'` after the edits and the scan returned no matches, indicating no remaining non-ASCII characters in the targeted files (success). 
- Ran the normalization script (`python` translation run shown in the rollout) which printed the list of modified files and completed successfully. 
- Verified repository state with `git status --short` which showed a clean working tree after committing the changes (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999dc63b54c832fbee54c80d4c51741)