### PR TITLE
Dodanie #prefix2 dla systemow jaskin (Pawlikowskiego, Wielka Sniezna)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Wszystkie istotne zmiany w projekcie "Jaskiniowy Kataster Tatr" sa udokumentowan
 
 Format oparty jest o [Keep a Changelog](https://keepachangelog.com/), a wersjonowanie stosuje [Semantic Versioning](https://semver.org/).
 
+## [v1.3.6] - 2026-05-05
+
+Poprawiono prefixy systemów: Jaskiń Pawlikowskiego oraz Wielkiej Śnieżnej. Zapewnia to poprawny export tych systemów.
+
+### Naprawione
+- Prefixy systemów Jaskiń Pawlikowskiego oraz Wielkiej Śnieżnej
+
 ## [v1.3.5] - 2026-05-03
 
 Poprawiono strukturę Releasu na GitHub'ie. Zmiany dotyczące prefixów dla jaskiń Czarna oraz Goryczkowa

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/BCDCHCG.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/BCDCHCG.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/BCWOKWYJ.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/BCWOKWYJ.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/BOKI_CG.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/BOKI_CG.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/CG.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/CG.SRV
@@ -14,6 +14,7 @@ TEAM "Filip Filar"
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #Units meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/CPBUL.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/CPBUL.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/MYLNA_M.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/MYLNA_M.SRV
@@ -11,6 +11,7 @@ DATA_SOURCE		"Panstwowy Instytut Geologiczny, F. Filar"
 LICENSE			"http://creativecommons.org/licenses/by-sa/4.0/"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #flag	0	/Mylna
 #flag	0	/ENTRANCE

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/SKIOKOL.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/SKIOKOL.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/ULPAWLCB.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/ULPAWLCB.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/ULPAWLCG.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/ULPAWLCG.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/WIIOKOL.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/WIIOKOL.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/WSZCZCB.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/WSZCZCB.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar" TODO: reszta zespolu??
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/WSZCZCG.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Mylna/WSZCZCG.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar i M. Parczewski"
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Mylna
 #date 2009-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Oblazkowa/OBLAZK_M.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Oblazkowa/OBLAZK_M.SRV
@@ -11,6 +11,7 @@ DATA_SOURCE		"Panstwowy Instytut Geologiczny, F. Filar"
 LICENSE			"http://creativecommons.org/licenses/by-sa/4.0/"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Oblazkowa
 #flag	0.0	/Oblazkowa
 #flag	0.0	/ENTRANCE

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Oblazkowa/OBLAZK_S.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Oblazkowa/OBLAZK_S.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar, M. Parczewski, B. Chlipala"
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Oblazkowa
 #date 2013-12-01
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Powierzchnia/POW_ORM.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Powierzchnia/POW_ORM.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar"
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix PawlikowskiegoPow
 #date 2014-01-01 ;TODO data szacunkowa
 #UNITS meters order=dav

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Raptawicka/RAPTAW_M.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Raptawicka/RAPTAW_M.SRV
@@ -11,6 +11,7 @@ DATA_SOURCE		"Panstwowy Instytut Geologiczny, F. Filar"
 LICENSE			"http://creativecommons.org/licenses/by-sa/4.0/"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Raptawicka
 #flag	1.0	/Raptawicka
 #flag	1.0	/ENTRANCE

--- a/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Raptawicka/RAPTAW_S.SRV
+++ b/Poligony/D_Koscieliska/Kom_Wierch/Rapt_Turnia/Syst_Pawlikowskiego/Raptawicka/RAPTAW_S.SRV
@@ -14,6 +14,7 @@ TEAM "F. Filar, M. Parczewski"
 INSTRUMENT "DistoX2"
 #]
 
+#prefix2 Pawlikowskiego
 #prefix Raptawicka
 #date 2014-01-01
 #UNITS meters order=dav

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/20130713.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/20130713.SRV
@@ -5,8 +5,9 @@
 #date 2013-07-13
 ;Marcin Slowik (kartowanie-PDA + spray), Karol Makowski (DistoX)
 ;delta DistoX = ?
-#prefix WielkaSniezna.Przemko1
-1.0	WielkaSniezna.Przemkow:pNkk19	0	0	0
+#prefix2 WielkaSniezna
+#prefix Przemko1
+1.0	Przemkow:pNkk19	0	0	0
 1.0	1.1	303.59	74.15	13.684
 1.1	1.2	30.73	76.05	6.379;1.2 do powtorki, strzal z 1.1 blisko stalowego karabinka, powtorzenie z punku ok. 0,5m nizej, NIE! BYLO CHYBA DOBRZE
 1.2	1.3	305.87	15.78	3.82
@@ -45,7 +46,8 @@
 #date 2015-01-04
 ;Karol Makowski (kartowanie-PDA + DistoX), Marcin Slowik (Spray)
 ;delta DistoX = 0.55
-#prefix WielkaSniezna.Przemko2
+#prefix2 WielkaSniezna
+#prefix Przemko2
 
 ;1.0	1.1	266.65	20.79	5.25;Powtorzony pomiar
 1.1	2.0	288.04	-11.81	4.847;Brak zaznaczonego punktu na scianie; trzeba obic i zaporeczowac trawers studni
@@ -169,7 +171,8 @@
 #date 2015-01-04
 ;Karol Makowski (kartowanie-PDA + DistoX), Marcin Slowik (Spray)
 ;delta DistoX = 0.55
-#prefix WielkaSniezna.Przemko3
+#prefix2 WielkaSniezna
+#prefix Przemko3
 ;Kilkutonowy glaz na spagu "Zawieszonej salki"; pod nim zaczyna sie niewielki meander, z ktorego woda wyplywa i spada w postaci deszczu w kominie Totoro.
 1.0	1.1	108.64	56.82	15.985;Punkt pomiarowy na pochylni z kaskadowymi prozkami
 1.1	2.0	79.93	35.64	7.196;Poczatek dosc ciasnego meandra - 0,3-0,5 m szerokosci; po 10-15 m meander konczy sie niewieka kaluza; mozliwa kontynuacja, ale czolganie w wodzie!
@@ -251,7 +254,8 @@
 #date 2015-01-05
 ;Karol Makowski (kartowanie-PDA + DistoX), Marcin Slowik (Spray)
 ;delta DistoX = 0.55
-#prefix WielkaSniezna.Przemko4
+#prefix2 WielkaSniezna
+#prefix Przemko4
 
 1.0	1.1	276.72	-84.49	25.806;Punkt 1.1 z ciagu pomiarowego "przemko2" - poczatek komina Totoro.
 1.1	1.2	161.7	-74.06	4.327;Dno komina Totoro.
@@ -327,6 +331,6 @@
 1.7	-	171.5	-61.71	5.97
 1.7	-	307.48	-77.44	4.399
 
-WielkaSniezna.Przemko1:1.10	WielkaSniezna.Przemko2:1.1	0	0	0
-WielkaSniezna.Przemko2:1.10	WielkaSniezna.Przemko3:1.0	0	0	0
-WielkaSniezna.Przemko1:1.10	WielkaSniezna.Przemko4:1.0	0	0	0
+Przemko1:1.10	Przemko2:1.1	0	0	0
+Przemko2:1.10	Przemko3:1.0	0	0	0
+Przemko1:1.10	Przemko4:1.0	0	0	0

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/AMOKI.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/AMOKI.SRV
@@ -2,8 +2,9 @@
 #Units A=grads
 #Units V=grads
 #Units Meters Order=dav
-#prefix WielkaSniezna.Amoki
-WielkaSniezna.Ciag:s47	a0	6.0	75	20
+#prefix2 WielkaSniezna
+#prefix Amoki
+Ciag:s47	a0	6.0	75	20
 a4	a5	16.05	200	-52
 a3	a4	11.7	210	-51
 a2	a3	3.55	140	6

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/JASNYA.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/JASNYA.SRV
@@ -3,7 +3,8 @@
 ;
 ;
 #units order=avd
-#prefix WielkaSniezna.Jasna
+#prefix2 WielkaSniezna
+#prefix Jasna
 #FIX  j0   E19:55:16.75  N49:14:22.58   1852m
 #note	j0	/Jasny Awen
 #flag	j0	/Jasny Awen

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/KOLANKO.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/KOLANKO.SRV
@@ -1,8 +1,9 @@
 ;Kolanko
 #units order=avd
-#prefix WielkaSniezna.Kolanko
+#prefix2 WielkaSniezna
+#prefix Kolanko
 ;
-WielkaSniezna.Ciag:w1	KO000	19.83	-55.99	13.70
+Ciag:w1	KO000	19.83	-55.99	13.70
 KOKO00	KOKO01	331.62	0.00	0.99
 KOKO01	KOKO02	199.96	12.82	2.07
 KOKO02	KOKO03	178.04	-43.20	5.22

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/KRAKOW.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/KRAKOW.SRV
@@ -1,7 +1,8 @@
 ;Kominy krakowskie
 #units order=avd
-#prefix WielkaSniezna.Krakow
-WielkaSniezna.Ciag:s35	k1	105	-9	13.44
+#prefix2 WielkaSniezna
+#prefix Krakow
+Ciag:s35	k1	105	-9	13.44
 k1	k2	81	30	19.30
 k2	k3	3	55	11.25
 k3	k4	299	30	2.58

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/KROKODYL.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/KROKODYL.SRV
@@ -1,8 +1,9 @@
 ;Galeria Krokodyla
 #units order=avd
-#prefix WielkaSniezna.Krokodyl
+#prefix2 WielkaSniezna
+#prefix Krokodyl
 ;			.
-WielkaSniezna.Ciag:g27	gk0	284	-35	4.90
+Ciag:g27	gk0	284	-35	4.90
 gk0	gk1	285	6	5.70
 gk1	gk2	262	0	6.80
 gk2	gk3	230	15	3.90

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/LITWOR.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/LITWOR.SRV
@@ -3,7 +3,8 @@
 #units v=d
 #units a=d
 #Units Meters Order=avd
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 ;#fix 	LT58	 0421006	5454543	1906
 #FIX  LT58  E19:54:53.26989 N49:14:18.82979 1903m
 #note	LT58	/Wielka Litworowa
@@ -500,8 +501,8 @@ LTcm89	LTcm88	140	-44	6.2
 LTcm88	LTcm87	140	-41	6.6
 ;uwaga pomiar gkplk dopisany
 ;TODO
-LTcm87	WielkaSniezna.Krokodyl:gkPLk	0	0	0
-;LTcm87	WielkaSniezna.Krokodyl:gkPLk	162	-52	25.2
+LTcm87	Krokodyl:gkPLk	0	0	0
+;LTcm87	Krokodyl:gkPLk	162	-52	25.2
 ;ltsa ciag boczny do studni Anielki
 LTz98	LTsa97	186	-7	6.4
 LTsa97	LTsa96	185	5	2.9

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/MAIN.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/MAIN.SRV
@@ -1,5 +1,6 @@
 #Units Meters Order=avd
-#prefix WielkaSniezna.Ciag
+#prefix2 WielkaSniezna
+#prefix Ciag
 ;#FIX  0   E19:55:15.15  N49:14:22.32   1875m
 #note	0	/Nad Kotliny
 #flag	0	/Nad Kotliny
@@ -16,7 +17,7 @@
 3	4	100	-31	25.00
 4	5	65	-26	17.20
 ;wyliczony domiar do Jasnego Avenu
-4	WielkaSniezna.Jasna:j20	339	24	14.5
+4	Jasna:j20	339	24	14.5
 5	6	103	-36	4.30
 6	7	80	-46	3.70
 7	8	82	-20	3.90

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/PRZEMKOW.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/PRZEMKOW.SRV
@@ -1,8 +1,9 @@
 ;Biala Woda
 ;
-#prefix WielkaSniezna.Przemkow
+#prefix2 WielkaSniezna
+#prefix Przemkow
 #units order=avd
-WielkaSniezna.Ciag:g36	b1	256.5	22.5	2.40
+Ciag:g36	b1	256.5	22.5	2.40
 b1	b2	292.5	17	5.30
 b2	b3	319.5	48	12.00
 b3	b4	261	20	8.00

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/SYFONKRA.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/SYFONKRA.SRV
@@ -1,7 +1,8 @@
 ;Syfon Krakowski
 #units order=avd
-#prefix WielkaSniezna.SyfonK
-WielkaSniezna.Ciag:g30	SK1	124.05	-40.01	12.10
+#prefix2 WielkaSniezna
+#prefix SyfonK
+Ciag:g30	SK1	124.05	-40.01	12.10
 SK1	SK2	125.98	-24.98	9.80
 SK2	SK3	158.01	-20.99	5.89
 SK3	SK4	159.97	-26.00	11.40

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/WARSZAW.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/WARSZAW.SRV
@@ -1,8 +1,9 @@
 ;Warszawskie kaskady
 ;
 #units order=avd
-#prefix WielkaSniezna.Warszaw
-WielkaSniezna.Ciag:w21	wk1	23	31	1.60
+#prefix2 WielkaSniezna
+#prefix Warszaw
+Ciag:w21	wk1	23	31	1.60
 wk1	wk2	312	-11	2.60
 wk2	wk3	350	3	1.20
 wk3	wk4	270	9	5.80
@@ -62,5 +63,5 @@ wk138	wk139	327	5.5	3.50
 wk139	wk1310	283	20	3.20
 wk1310	wk1311	180	0	2.40
 wk1311	wk1312	71	42	4.50
-wk1312	WielkaSniezna.Ciag:w11	139	-39	1.40
+wk1312	Ciag:w11	139	-39	1.40
 

--- a/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/WROCL.SRV
+++ b/Poligony/D_Malej_Laki/Przechod-Kotliny/Syst_W_Snieznej/sniezna/WROCL.SRV
@@ -3,8 +3,9 @@
 ;
 ;
 #units order=avd
-#prefix WielkaSniezna.Wrocl
-WielkaSniezna.Ciag:g83	z0	190	-22	7.00
+#prefix2 WielkaSniezna
+#prefix Wrocl
+Ciag:g83	z0	190	-22	7.00
 z0	z1	287	1	6.20
 z1	z2	279	-11	7.15
 z2	z3	295	5	4.65

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/KOPERNIK.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/KOPERNIK.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 #u meters
 ;sala kopernika i okolice
 ;pomiary: Czeslaw Szura, Artur Zera

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LIT99.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LIT99.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 #u meters
 #units order=dva
 ;wszystkie pomiary zawieraja sie w pliku SBB2, intencja nieznana

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LITPLYTB.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LITPLYTB.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 ;Bielskie stare-nowe pomiary
 #Units Meters Order=avd
 #note  LTII20 /  punkt -160

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LITSTARE.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LITSTARE.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 ;Litworowa
 ;
 #units v=d
@@ -500,8 +501,8 @@ LTcm89	LTcm88	140	-44	6.2
 LTcm88	LTcm87	140	-41	6.6
 ;uwaga pomiar gkplk dopisany
 ;TODO
-LTcm87	WielkaSniezna.Krokodyl:gkPLk	0	0	0
-;LTcm87	WielkaSniezna.Krokodyl:gkPLk	162	-52	25.2
+LTcm87	Krokodyl:gkPLk	0	0	0
+;LTcm87	Krokodyl:gkPLk	162	-52	25.2
 ;ltsa ciag boczny do studni Anielki
 LTz98	LTsa97	186	-7	6.4
 LTsa97	LTsa96	185	5	2.9

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LTPSB.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LTPSB.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 #u meters
 #units order=dav
 LTpsb0	LTsb1	2.1	0	-90

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LTPWG.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/LTPWG.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 #units v=d
 #units a=d
 #Units Meters Order=avd

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/SBB2.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/SBB2.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 ;LTsbb Bielskie nowe
 #Units DECL=3.5
 #u meters

--- a/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/SLEPE.SRV
+++ b/Poligony/D_Mietusia/Litw_Dolina/W_Litworowa/SNIEZNA/SLEPE.SRV
@@ -1,4 +1,5 @@
-#prefix WielkaLitworowa
+#prefix2 WielkaSniezna
+#prefix Litworowa
 #u meters
 ;partie slepych
 ;pomiary: Artur Zera, Jakub Pysz, Alan Zera

--- a/Poligony/_Domiary_Pow_/SNIEZNA/LITW_TER.SRV
+++ b/Poligony/_Domiary_Pow_/SNIEZNA/LITW_TER.SRV
@@ -15,6 +15,6 @@ ter4	ter5	5.38	-75	150
 ter2	ter6	2.63	9	211
 ter6	ter7	60.0	-14	192
 ter7	ter8	33.5	18	226
-ter8	WielkaLitworowa:LT58	3.18	-28	210
+ter8	WielkaSniezna:Litworowa:LT58	3.18	-28	210
 ter7	ter7a	28.07	48	140
 ter7a	ter7b	5.0	7	165


### PR DESCRIPTION
System Pawlikowskiego: #prefix2 Pawlikowskiego dla Mylnej, Oblazkowej, Raptawickiej i ciagu powierzchniowego (17 plikow).

System Wielkiej Snieznej: #prefix2 WielkaSniezna, skrocenie prefiksow z WielkaSniezna.Xxx na Xxx, aktualizacja odwolan miedzy plikami (11 plikow). LITWOR.SRV pominiety (STATUS 10, wspoldzielony z D_Mietusia).