### PR TITLE
[codex] Dodaj uzupełniające zbiory danych do README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -15,6 +15,13 @@
 ### Project Description
 The project aims to compile all cartographic data related to the caves of the Tatra Mountains in one place. Utilizing the Walls software, the primary goal is to create a spatial compilation of measurement sequences, cave entrance coordinates, and terrain models. The project is open to all who are interested, to facilitate exploratory and educational activities, and to support scientific research. Gathering comprehensive and accurate data presents a challenge due to the diversity of methods and times of their execution.
 
+### Complementary Data Sets
+
+The registry contains objects for which cave survey data is available. Two related data sets complement it by also covering objects that are not yet present in this repository:
+
+- [GPS Kataster Obiektów Tatr](https://github.com/dlubom/gps-kataster-obiektow-tatr) — a database of GPS locations for cave entrances and other field objects. This project uses its published best GPS measurements to determine entrance coordinates. Ready-to-use GIS and field data can be downloaded from the [latest release](https://github.com/dlubom/gps-kataster-obiektow-tatr/releases/latest).
+- [Georeferencer](https://github.com/dlubom/Georeferencer) — georeferenced scans of cave plans in GeoTIFF format, including objects without survey data in this registry. A ready-to-use GeoTIFF package can be downloaded from the [latest release](https://github.com/dlubom/Georeferencer/releases/latest).
+
 The project is based on the Walls software – you can find the [latest version of the program and its manual here](http://texasspeleologicalsurvey.org/Walls/tsswalls.htm).
 
 The project also works with [Survex](https://survex.com/) — just install the latest version and open `KATASTER.wpj` in Aven, or compile from the command line: `cavern KATASTER.wpj`. In Aven you can also load the terrain model `Powierzchnia/Survex/N49E019_VF1.hgt`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@
 ### Opis projektu
 Projekt ma na celu zgromadzenie w jednym miejscu wszystkich danych kartograficznych dotyczących tatrzańskich jaskiń. Wykorzystując oprogramowanie Walls, głównym celem jest stworzenie zestawienia przestrzennego ciągów pomiarowych, współrzędnych wejść do jaskiń oraz modelu terenu. Projekt jest otwarty dla wszystkich zainteresowanych, by ułatwić działania eksploracyjne, edukacyjne oraz wspierać badania naukowe. Zebranie kompleksowych i dokładnych danych stanowi wyzwanie ze względu na różnorodność metod i czasu ich wykonania.
 
+### Uzupełniające zbiory danych
+
+Kataster obejmuje obiekty, dla których dostępne są dane pomiarowe. Uzupełniają go dwa powiązane zbiory obejmujące także obiekty, których nie ma jeszcze w tym repozytorium:
+
+- [GPS Kataster Obiektów Tatr](https://github.com/dlubom/gps-kataster-obiektow-tatr) — baza lokalizacji GPS otworów jaskiń i innych obiektów terenowych. Ten projekt korzysta z publikowanych w niej najlepszych pomiarów GPS do wyznaczania współrzędnych wejść. Gotowe dane GIS i terenowe można pobrać z [najnowszego wydania](https://github.com/dlubom/gps-kataster-obiektow-tatr/releases/latest).
+- [Georeferencer](https://github.com/dlubom/Georeferencer) — georeferencjonowane skany planów jaskiń w formacie GeoTIFF, obejmujące również obiekty bez danych pomiarowych w tym katastrze. Gotową paczkę GeoTIFF można pobrać z [najnowszego wydania](https://github.com/dlubom/Georeferencer/releases/latest).
+
 Projekt oparty jest o oprogramowanie Walls – tutaj znajdziesz [najnowszą wersję programu](https://github.com/wallscavesurvey/walls/releases)  oraz [instrukcję obsługi](http://texasspeleologicalsurvey.org/Walls/tsswalls.htm).
 
 Projekt działa również w [Survex](https://survex.com/) — wystarczy zainstalować najnowszą wersję i wczytać plik `KATASTER.wpj` w programie Aven lub skompilować z linii poleceń: `cavern KATASTER.wpj`. W Aven można też wczytać model terenu `Powierzchnia/Survex/N49E019_VF1.hgt`.

--- a/README.sk.md
+++ b/README.sk.md
@@ -15,6 +15,13 @@
 ### Popis projektu
 Projekt má za cieľ zhromaždiť všetky kartografické údaje o tatranských jaskyniach na jednom mieste. Využitím softvéru Walls je hlavným cieľom vytvoriť priestorové zosumarizovanie meracích postupov, súradníc vstupov do jaskýň a modelu terénu. Projekt je otvorený pre všetkých záujemcov, aby uľahčil prieskumné, vzdelávacie a podporoval vedecký výskum. Zhromaždenie komplexných a presných údajov predstavuje výzvu kvôli rozmanitosti metód a času ich vykonávania.
 
+### Doplňujúce súbory údajov
+
+Kataster obsahuje objekty, pre ktoré sú k dispozícii údaje z jaskynných meraní. Dopĺňajú ho dva súvisiace súbory údajov, ktoré zahŕňajú aj objekty, ktoré zatiaľ nie sú v tomto repozitári:
+
+- [GPS Kataster Obiektów Tatr](https://github.com/dlubom/gps-kataster-obiektow-tatr) — databáza GPS polôh vchodov do jaskýň a ďalších terénnych objektov. Tento projekt používa zverejnené najlepšie GPS merania na určenie súradníc vchodov. Hotové údaje pre GIS a prácu v teréne si môžete stiahnuť z [najnovšieho vydania](https://github.com/dlubom/gps-kataster-obiektow-tatr/releases/latest).
+- [Georeferencer](https://github.com/dlubom/Georeferencer) — georeferencované skeny plánov jaskýň vo formáte GeoTIFF, ktoré zahŕňajú aj objekty bez údajov z meraní v tomto katastri. Hotový balík GeoTIFF si môžete stiahnuť z [najnovšieho vydania](https://github.com/dlubom/Georeferencer/releases/latest).
+
 Projekt je založený na softvéri Walls – [tu nájdete najnovšiu verziu programu a návod na použitie](http://texasspeleologicalsurvey.org/Walls/tsswalls.htm).
 
 Projekt funguje aj v programe [Survex](https://survex.com/) — stačí nainštalovať najnovšiu verziu a otvoriť súbor `KATASTER.wpj` v programe Aven alebo skompilovať z príkazového riadku: `cavern KATASTER.wpj`. V programe Aven je možné načítať aj model terénu `Powierzchnia/Survex/N49E019_VF1.hgt`.


### PR DESCRIPTION
## Co zmieniono

- dodano sekcję o uzupełniających zbiorach danych do polskiego, angielskiego i słowackiego README;
- opisano `dlubom/gps-kataster-obiektow-tatr` jako bazę lokalizacji GPS, z której kataster pobiera najlepsze pomiary współrzędnych wejść;
- opisano `dlubom/Georeferencer` jako źródło georeferencjonowanych planów jaskiń w formacie GeoTIFF;
- dodano odnośniki do repozytoriów oraz ich najnowszych wydań przeznaczonych dla zwykłych użytkowników.

## Dlaczego

Oba zbiory obejmują również obiekty bez danych pomiarowych w tym katastrze. README powinny jasno wskazywać, gdzie znaleźć uzupełniające lokalizacje GPS i plany GeoTIFF oraz wyjaśniać zależność współrzędnych wejść od GPS Kataster Obiektów Tatr.

## Wpływ

Zmiana dotyczy wyłącznie dokumentacji i zachowuje ten sam zakres znaczeniowy we wszystkich trzech językach.

## Weryfikacja

- `uv run pytest` — 64 testy przeszły;
- `git diff --check`;
- wszystkie cztery dodane adresy repozytoriów i najnowszych wydań zwracają HTTP 200.